### PR TITLE
Update vignette engine to knitr::rmarkdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description: An R package providing extended biological annotations for
     public repositories. For more information on the SomaScan assay 
     and its data, please see 
     <https://github.com/SomaLogic/SomaLogic-Data/blob/master/README.md>.
-Version: 0.99.5
+Version: 0.99.6
 Authors@R: 
     c(person(given = "Amanda", 
              family = "Hiser",

--- a/vignettes/SomaScan.db.Rmd
+++ b/vignettes/SomaScan.db.Rmd
@@ -7,7 +7,7 @@ output:
       toc_float: true
 vignette: >
   %\VignetteIndexEntry{Introduction to SomaScan.db}
-  %\VignetteEngine{knitr::knitr}
+  %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
 

--- a/vignettes/advanced_usage_examples.Rmd
+++ b/vignettes/advanced_usage_examples.Rmd
@@ -7,7 +7,7 @@ output:
       toc_float: true
 vignette: >
   %\VignetteIndexEntry{Advanced Exploration of the SomaScan Menu}
-  %\VignetteEngine{knitr::knitr}
+  %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
 

--- a/vignettes/example_adat_workflow.Rmd
+++ b/vignettes/example_adat_workflow.Rmd
@@ -7,7 +7,7 @@ output:
       toc_float: true
 vignette: >
   %\VignetteIndexEntry{Example ADAT Workflow Using SomaScan.db}
-  %\VignetteEngine{knitr::knitr}
+  %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
 


### PR DESCRIPTION
- change will enable use of BiocStyle table of contents in vignettes
- vignette engine changed from knitr::knitr to knitr::rmarkdown
- bumped version number (patch) to trigger Bioc build