### PR TITLE
Remove URL from package description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,10 +3,10 @@ Title: Somalogic SomaScan Annotation Data
 Description: An R package providing extended biological annotations for 
     the SomaScan Assay, a proteomics platform developed by SomaLogic Operating 
     Co., Inc. The annotations in this package were assembled using data from 
-    public repositories. For more information on the SomaScan assay 
-    and its data, please see 
-    <https://github.com/SomaLogic/SomaLogic-Data/blob/master/README.md>.
-Version: 0.99.6
+    public repositories. For more information about the SomaScan assay 
+    and its data, please reference the 'SomaLogic/SomaLogic-Data' GitHub 
+    repository.
+Version: 0.99.7
 Authors@R: 
     c(person(given = "Amanda", 
              family = "Hiser",


### PR DESCRIPTION
- removed URL linking to the SomaLogic-Data GitHub repo from the "Description" field of the DESCRIPTION file
- URL was not displayed correctly on Bioc website
- bumped version (patch)