### PR TITLE
Minor tweaks for pkgdown; remove vignettes `abstract` element

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
-# SomaScan.db 0.99.7
-* Created pkgdown site
+# SomaScan.db 0.99.8
+* Launched pkgdown site
 
 # SomaScan.db 0.99.6
 * Updated vignette engine to use `knitr::rmarkdown`

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,13 +13,16 @@ knitr::opts_chunk$set(
   comment = "#>",
   fig.path = "man/figures/README-"
 )
-ver <- desc::desc_get_version(".")
-ver <- paste0("https://img.shields.io/badge/Version-", ver,
+dcf <- read.dcf(file = file.path(".", "DESCRIPTION"))
+if ( nrow(dcf) < 1L) 
+  stop("DESCRIPTION file of package is corrupt.", call. = FALSE)
+desc <- as.list(dcf[1L, ])
+ver <- paste0("https://img.shields.io/badge/Version-", desc$Version,
               "-success.svg?style=flat&logo=github")
 ```
 
 
-# `SomaScan.db` <img src="inst/figures/logo.png" align="right" height="138" alt="" />
+# SomaScan.db
 
 
 <!-- badges: start -->
@@ -30,7 +33,7 @@ ver <- paste0("https://img.shields.io/badge/Version-", ver,
 [![Bioc support](https://bioconductor.org/shields/posts/SomaScan.db.svg)](https://support.bioconductor.org/tag/SomaScan.db)
 <!-- badges: end -->
 
-# Oveview
+# Overview
 
 The `SomaScan.db` package is a platform-centric R package that provides 
 extended biological annotations for analytes in the SomaScan assay menu, using 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# `SomaScan.db` <img src="inst/figures/logo.png" align="right" height="138" alt="" />
+# SomaScan.db
 
 <!-- badges: start -->
 
@@ -17,7 +17,7 @@ rank](https://bioconductor.org/shields/downloads/release/SomaScan.db.svg)](https
 support](https://bioconductor.org/shields/posts/SomaScan.db.svg)](https://support.bioconductor.org/tag/SomaScan.db)
 <!-- badges: end -->
 
-# Oveview
+# Overview
 
 The `SomaScan.db` package is a platform-centric R package that provides
 extended biological annotations for analytes in the SomaScan assay menu,

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -23,7 +23,7 @@ footer:
     left: [package, developed_by]
     right: built_with
   components:
-    logo: "<img src='inst/figures/logo.png' width='20'> "
+    logo: "<img src='favicon-16x16.png'>"
 
 template:
   bootstrap: 5
@@ -43,7 +43,7 @@ home:
         text: >
           [SomaDataIO](https://somalogic.github.io/SomaDataIO/) <br />
           [SomaPlotr](https://somalogic.github.io/SomaPlotr/) <br />
-          [Canopy](https://github.com/SomaLogic/Canopy/) <br />
+          [Canopy (Python)](https://github.com/SomaLogic/Canopy/) <br />
           [DataDelve Statistics](https://somalogic.com/datadelve-statistics/)
       help:
         title: Getting Help

--- a/vignettes/SomaScan-db.Rmd
+++ b/vignettes/SomaScan-db.Rmd
@@ -1,6 +1,5 @@
 ---
 title: "Introduction to SomaScan.db"
-abstract: "Brief overview of an annotation package for SomaLogic SomaScan data."
 package: "`r BiocStyle::pkg_ver('SomaScan.db')`"
 output: 
   BiocStyle::html_document:

--- a/vignettes/advanced_usage_examples.Rmd
+++ b/vignettes/advanced_usage_examples.Rmd
@@ -1,6 +1,5 @@
 ---
 title: "Advanced Exploration of the SomaScan Menu"
-abstract: "Advanced use cases of SomaScan.db, including SomaScan menu exploration examples."
 package: "`r BiocStyle::pkg_ver('SomaScan.db')`"
 output: 
   BiocStyle::html_document:

--- a/vignettes/example_adat_workflow.Rmd
+++ b/vignettes/example_adat_workflow.Rmd
@@ -1,6 +1,5 @@
 ---
 title: "Example ADAT Workflow Using SomaScan.db"
-abstract: "A short workflow illustrating the use of SomaScan.db to annotate SomaScan data (as an ADAT)."
 package: "`r BiocStyle::pkg_ver('SomaScan.db')`"
 output: 
   BiocStyle::html_document:


### PR DESCRIPTION
- removed "Abstract" section from vignettes, as this is covered by the vignette "Introduction" section
- removed SomaLogic logo from README
- updated NEWS file to reflect addition of pkgdown site